### PR TITLE
Set widget min deployment target to iOS 16

### DIFF
--- a/MoodTracker.xcodeproj/project.pbxproj
+++ b/MoodTracker.xcodeproj/project.pbxproj
@@ -603,7 +603,7 @@
 				INFOPLIST_FILE = MoodTrackerWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MoodTrackerWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -632,7 +632,7 @@
 				INFOPLIST_FILE = MoodTrackerWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MoodTrackerWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
- Set the widget's minimum deployment target to iOS 16 so that it matches the main app's min deployment target